### PR TITLE
Docker設定の修正（restart設定の無効化）

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,7 +1,7 @@
 services:
   db:
     image: postgres:13
-    restart: always
+    restart: "no"
     environment:
       POSTGRES_HOST: localhost
       POSTGRES_PORT: 5432


### PR DESCRIPTION
* **再起動設定の明示化**
    * 他プロジェクトとのポート競合や、Docker起動時に意図せずコンテナが立ち上がるのを防ぐため、`restart` 設定を `"no"` に変更・明示しました。