### PR TITLE
feat: MFAメール認証対応を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "express": "^4.19.2",
         "pg": "^8.13.0",
         "reflect-metadata": "^0.2.2",
-        "saasus-sdk": "^1.3.2",
+        "saasus-sdk": "^1.13.2",
         "typeorm": "^0.3.20"
       },
       "devDependencies": {
@@ -1892,17 +1892,18 @@
       }
     },
     "node_modules/saasus-sdk": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/saasus-sdk/-/saasus-sdk-1.10.18.tgz",
-      "integrity": "sha512-OIttQrziSuUB2MHhiIGBen+7Mcd14fE/rGkF90j+ZgAOiDMBlfZUIlWfotPjQcQ3EoDWp3OW3xSq3szwJ7VK1w==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/saasus-sdk/-/saasus-sdk-1.13.2.tgz",
+      "integrity": "sha512-P4eXK269UqXboBeKNv3wb6cNCsfSyNylQVOWY55HrpSjQRvUDPa01NsZUqnvliGbWfOcPoihP2BOYuPQeVPmzg==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "axios": "^1.1.3",
+        "axios": "^1.2.1",
         "crypto-js": "^4.1.1",
         "date-and-time": "^2.4.1"
       },
       "peerDependencies": {
-        "axios": "^1.1.3",
+        "axios": "^1.2.1",
         "crypto-js": "^4.1.1",
         "date-and-time": "^2.4.1"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "express": "^4.19.2",
     "pg": "^8.13.0",
     "reflect-metadata": "^0.2.2",
-    "saasus-sdk": "^1.3.2",
+    "saasus-sdk": "^1.13.2",
     "typeorm": "^0.3.20"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ app.use(
       '/mfa_setup',
       '/mfa_verify',
       '/mfa_enable',
+      '/mfa_email_enable',
       '/mfa_disable',
     ],
     AuthMiddleware
@@ -618,8 +619,8 @@ app.get('/mfa_status', async (request: Request, response: Response) => {
         return response.status(400).json({ detail: 'No user' })
     }
     const mfaPref = (await client.saasUserApi.getUserMfaPreference(userInfo.id)).data
-    // enabled フラグを返す
-    response.json({ enabled: mfaPref.enabled })
+    // enabled フラグと認証方式を返す
+    response.json({ enabled: mfaPref.enabled, method: mfaPref.method || null })
   } catch (error) {
     console.error(error)
     response.status(500).json({ detail: error })
@@ -688,7 +689,7 @@ app.post('/mfa_verify', async (request: Request, response: Response) => {
   }
 })
 
-// MFA有効化エンドポイント
+// MFA有効化エンドポイント（認証アプリ）
 app.post('/mfa_enable', async (request: Request, response: Response) => {
   const userInfo = request.userInfo
   if (!userInfo) {
@@ -698,7 +699,7 @@ app.post('/mfa_enable', async (request: Request, response: Response) => {
   try {
     const client = new AuthClient()
 
-    // MFA設定を有効にする
+    // MFA設定を認証アプリで有効にする
     const mfaPreference: MfaPreference = {
       enabled: true,
       method: 'softwareToken'
@@ -706,6 +707,30 @@ app.post('/mfa_enable', async (request: Request, response: Response) => {
     await client.saasUserApi.updateUserMfaPreference(userInfo.id, mfaPreference)
 
     response.json({ message: 'MFA has been enabled' })
+  } catch (error) {
+    console.error(error)
+    response.status(500).json({ detail: error })
+  }
+})
+
+// MFAメール認証有効化エンドポイント
+app.post('/mfa_email_enable', async (request: Request, response: Response) => {
+  const userInfo = request.userInfo
+  if (!userInfo) {
+    return response.status(400).json({ detail: 'No user' })
+  }
+
+  try {
+    const client = new AuthClient()
+
+    // MFA設定をメール認証で有効にする
+    const mfaPreference: MfaPreference = {
+      enabled: true,
+      method: 'email'
+    }
+    await client.saasUserApi.updateUserMfaPreference(userInfo.id, mfaPreference)
+
+    response.json({ message: 'Email MFA has been enabled' })
   } catch (error) {
     console.error(error)
     response.status(500).json({ detail: error })


### PR DESCRIPTION
  ## 概要
  MFA認証方式にメール認証を追加し、フロントエンドの方式選択UIに対応するバックエンド改修です。
  
  ## 変更内容
  - `GET /mfa_status` レスポンスに `method` フィールドを追加
  - `POST /mfa_email_enable` エンドポイントを新規追加
  - saasus-sdk を ^1.3.2 → ^1.13.2 にアップデート
  
  ## Related PRs
  - saasus-platform/implementation-sample-front-react#24