### PR TITLE
feat: X-Saasus-Trace-Id 自動引継機能の追加

### DIFF
--- a/src/client-helpers.ts
+++ b/src/client-helpers.ts
@@ -1,0 +1,20 @@
+import { Request } from 'express'
+import { AuthClient, PricingClient } from 'saasus-sdk'
+
+export function getClientHeaders(req: Request) {
+  return {
+    referer: (req.headers['referer'] as string) || '',
+    xSaaSusReferer: (req.headers['x-saasus-referer'] as string) || '',
+    xSaaSusTraceId: (req.headers['x-saasus-trace-id'] as string) || '',
+  }
+}
+
+export function createAuthClient(req: Request): AuthClient {
+  const { referer, xSaaSusReferer, xSaaSusTraceId } = getClientHeaders(req)
+  return new AuthClient(referer, xSaaSusReferer, xSaaSusTraceId)
+}
+
+export function createPricingClient(req: Request): PricingClient {
+  const { referer, xSaaSusReferer, xSaaSusTraceId } = getClientHeaders(req)
+  return new PricingClient(referer, xSaaSusReferer, xSaaSusTraceId)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 import express, { Request, Response } from 'express'
-import { AuthClient, AuthMiddleware, CallbackRouteFunction, PricingClient } from 'saasus-sdk'
+import { AuthMiddleware, CallbackRouteFunction } from 'saasus-sdk'
 import cors from 'cors'
 import cookieParser from 'cookie-parser'
 import 'reflect-metadata'
@@ -18,6 +18,7 @@ import {
   MfaPreference,
 } from 'saasus-sdk/dist/generated/Auth'
 import billingRoutes from './routes/billingRoutes'
+import { createAuthClient, createPricingClient } from './client-helpers'
 
 const PORT = 80
 
@@ -29,7 +30,7 @@ app.use(
   cors({
     origin: 'http://localhost:3000',
     credentials: true,
-    allowedHeaders: ['Content-Type', 'Authorization', 'x-requested-with', 'X-Access-Token', 'x-saasus-referer'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'x-requested-with', 'X-Access-Token', 'x-saasus-referer', 'X-Saasus-Trace-Id'],
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   })
 )
@@ -89,7 +90,7 @@ app.get('/refresh', async (request: Request, response: Response) => {
     return
   }
 
-  const client = new AuthClient()
+  const client = createAuthClient(request)
   const credentials = (
     await client.credentialApi.getAuthCredentials(
       '',
@@ -122,7 +123,7 @@ app.get('/users', async (request: Request, response: Response) => {
     return response.status(400).json({ detail: 'Invalid tenant ID' });
   }
 
-  const client = new AuthClient()
+  const client = createAuthClient(request)
   const users = (await client.tenantUserApi.getTenantUsers(tenantId)).data.users
   response.send(users)
 })
@@ -145,7 +146,7 @@ app.get('/tenant_attributes', async(request: Request, response: Response) => {
   }
 
   try {
-    const client = new AuthClient()
+    const client = createAuthClient(request)
     const tenantAttributes = (await client.tenantAttributeApi.getTenantAttributes()).data
 
     const tenantInfo = (await client.tenantApi.getTenant(tenantId)).data
@@ -169,7 +170,7 @@ app.get('/tenant_attributes', async(request: Request, response: Response) => {
 
 app.get('/user_attributes', async(request: Request, response: Response) => {
   try {
-    const client = new AuthClient()
+    const client = createAuthClient(request)
     const userAttributes = (await client.userAttributeApi.getUserAttributes()).data
     
     response.json(userAttributes);
@@ -208,7 +209,7 @@ app.post('/user_register', async(request: Request, response: Response) => {
 
   try {
     // ユーザー属性情報を取得
-    const client = new AuthClient()
+    const client = createAuthClient(request)
     const userAttributesObj = (await client.userAttributeApi.getUserAttributes()).data
 
     let userAttributeValuesCopy = userAttributeValues || {}
@@ -289,7 +290,7 @@ app.delete('/user_delete', async (request: Request, response: Response) => {
 
   try {
       // SaaSusからユーザー情報を取得
-      const client = new AuthClient()
+      const client = createAuthClient(request)
       const deleteUser = (await client.tenantUserApi.getTenantUser(tenantId, userId)).data
 
       // テナントからユーザー情報を削除
@@ -395,7 +396,7 @@ app.get('/pricing_plan', async (request: Request, response: Response) => {
   }
 
   try {
-    const client = new PricingClient()
+    const client = createPricingClient(request)
     const plan = (await client.pricingPlansApi.getPricingPlan(planId)).data
     return response.json(plan);
   } catch (error) {
@@ -411,7 +412,7 @@ app.get('/tenant_attributes_list', async (request: Request, response: Response) 
   }
 
   try {
-    const client = new AuthClient()
+    const client = createAuthClient(request)
     const tenantAttributes = (await client.tenantAttributeApi.getTenantAttributes()).data
     return response.json(tenantAttributes);
   } catch (error) {
@@ -440,7 +441,7 @@ app.post('/self_sign_up', async(request: Request, response: Response) => {
 
   try {
     // ユーザー属性情報を取得
-    const client = new AuthClient()
+    const client = createAuthClient(request)
 
     // テナント属性情報の取得
     const tenantAttributesObj = (await client.tenantAttributeApi.getTenantAttributes()).data
@@ -538,7 +539,7 @@ app.get('/invitations', async(request: Request, response: Response) => {
     }
 
     // テナントの招待一覧を取得
-    const client = new AuthClient()
+    const client = createAuthClient(request)
     const invitations = (await client.invitationApi.getTenantInvitations(tenantId)).data.invitations
     // 招待情報を返却
     response.send(invitations)
@@ -594,7 +595,7 @@ app.post('/user_invitation', async(request: Request, response: Response) => {
     }
 
     // テナントへの招待を作成
-    const client = new AuthClient()
+    const client = createAuthClient(request)
     await client.invitationApi.createTenantInvitation(tenantId, createTenantInvitationParam)
 
     response.json({ message: 'Create tenant user invitation successfully' })
@@ -612,7 +613,7 @@ app.get('/mfa_status', async (request: Request, response: Response) => {
   }
   try {
     // 認証クライアント初期化
-    const client = new AuthClient()
+    const client = createAuthClient(request)
     // ユーザー情報からMFA設定を取得
     const userInfo = request.userInfo
     if (userInfo === undefined) {
@@ -634,7 +635,7 @@ app.get('/mfa_setup', async (request: Request, response: Response) => {
       return response.status(400).json({ detail: 'No user' })
     }
   try {
-    const client = new AuthClient()
+    const client = createAuthClient(request)
     const accessToken = request.header('X-Access-Token')
 
     if (!accessToken) {
@@ -668,7 +669,7 @@ app.post('/mfa_verify', async (request: Request, response: Response) => {
   }
 
   try {
-    const client = new AuthClient()
+    const client = createAuthClient(request)
     const accessToken = request.header('X-Access-Token')
     const { verification_code }: MfaVerifyRequest = request.body
 
@@ -697,7 +698,7 @@ app.post('/mfa_enable', async (request: Request, response: Response) => {
   }
 
   try {
-    const client = new AuthClient()
+    const client = createAuthClient(request)
 
     // MFA設定を認証アプリで有効にする
     const mfaPreference: MfaPreference = {
@@ -721,7 +722,7 @@ app.post('/mfa_email_enable', async (request: Request, response: Response) => {
   }
 
   try {
-    const client = new AuthClient()
+    const client = createAuthClient(request)
 
     // MFA設定をメール認証で有効にする
     const mfaPreference: MfaPreference = {
@@ -745,7 +746,7 @@ app.post('/mfa_disable', async (request: Request, response: Response) => {
   }
 
   try {
-    const client = new AuthClient()
+    const client = createAuthClient(request)
 
     // MFA設定を無効にする
     const mfaPreference: MfaPreference = {

--- a/src/routes/billingRoutes.ts
+++ b/src/routes/billingRoutes.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response, NextFunction } from "express";
-import { AuthClient, AuthMiddleware, PricingClient } from "saasus-sdk";
+import { AuthMiddleware, PricingClient } from "saasus-sdk";
 import type { PricingPlan } from "saasus-sdk/dist/generated/Pricing";
+import { createAuthClient, createPricingClient } from "../client-helpers";
 
 // --- 型定義 -----------------------------------------------------------
 interface TenantPlanResponse {
@@ -187,8 +188,8 @@ router.get('/billing/dashboard', async (req: Request, res: Response) => {
     if (!userInfo) return res.status(401).json({ message: 'Unauthenticated' });
 
     // SDK クライアント生成
-    const authCli = new AuthClient();
-    const pricingCli = new PricingClient();
+    const authCli = createAuthClient(req);
+    const pricingCli = createPricingClient(req);
 
     // クエリパラメータ
     const tenantId = String(req.query.tenant_id);
@@ -262,8 +263,8 @@ router.get("/billing/plan_periods", async (req: Request, res: Response) => {
     }
 
     // SDK 呼び出し準備
-    const authCli = new AuthClient();
-    const pricingCli = new PricingClient();
+    const authCli = createAuthClient(req);
+    const pricingCli = createPricingClient(req);
 
     // テナント情報取得
     const tenant = (await authCli.tenantApi.getTenant(tenantId)).data;
@@ -369,7 +370,7 @@ router.post(
     }
 
     try {
-      const pricingCli = new PricingClient();
+      const pricingCli = createPricingClient(req);
       const resp =
         await pricingCli.meteringApi.updateMeteringUnitTimestampCount(
           tenantId,
@@ -405,7 +406,7 @@ router.post(
     }
 
     try {
-      const pricingCli = new PricingClient();
+      const pricingCli = createPricingClient(req);
       const resp =
         await pricingCli.meteringApi.updateMeteringUnitTimestampCountNow(
           tenantId,
@@ -431,7 +432,7 @@ router.get("/pricing_plans", async (req: Request, res: Response) => {
       return res.status(401).json({ detail: "No user" });
     }
 
-    const pricingCli = new PricingClient();
+    const pricingCli = createPricingClient(req);
     const plans = (await pricingCli.pricingPlansApi.getPricingPlans()).data;
     res.json(plans.pricing_plans);
   } catch (error) {
@@ -451,7 +452,7 @@ router.get("/tax_rates", async (req: Request, res: Response) => {
       return res.status(401).json({ detail: "No user" });
     }
 
-    const pricingCli = new PricingClient();
+    const pricingCli = createPricingClient(req);
     const taxRates = (await pricingCli.taxRateApi.getTaxRates()).data;
     res.json(taxRates.tax_rates);
   } catch (error) {
@@ -481,7 +482,7 @@ router.get("/tenants/:tenant_id/plan", async (req: Request, res: Response) => {
       return res.status(403).json({ error: "Insufficient permissions" });
     }
 
-    const authCli = new AuthClient();
+    const authCli = createAuthClient(req);
     const tenant = (await authCli.tenantApi.getTenant(tenantId)).data;
 
     // 現在のプランの税率情報を取得（プラン履歴の最新エントリから）
@@ -542,7 +543,7 @@ router.put("/tenants/:tenant_id/plan", async (req: Request, res: Response) => {
       return res.status(403).json({ error: "Insufficient permissions" });
     }
 
-    const authCli = new AuthClient();
+    const authCli = createAuthClient(req);
 
     // テナントプランを更新
     const updateTenantPlanParam: UpdateTenantPlanParam = {


### PR DESCRIPTION
  概要
  
  フロントエンドから送信される X-Saasus-Trace-Id ヘッダーを受け取り、SaaSus SDK 経由の API
  リクエストに自動伝播する仕組みを追加しました。併せて、既存の referer / x-saasus-referer
  もハンドラー内のAPI呼び出しに伝播されるよう修正しています。
  
  変更内容
  
  - CORS の allowedHeaders に X-Saasus-Trace-Id を追加
  - src/client-helpers.ts を新規作成：リクエストヘッダーから referer / x-saasus-referer / x-saasus-trace-id
   を取得して各クライアントに渡すヘルパー関数
  - src/index.ts、src/routes/billingRoutes.ts の全 AuthClient / PricingClient 生成箇所をヘルパー経由に変更
  
  ローカルでの起動方法
  
  SDK
  PR（saasus-platform/saasus-sdk-javascript#104）がまだリリースされていないため、ローカルでの動作確認には以下が必要
  です：
  
  1. saasus-sdk-javascript リポジトリの [add_x_saasus_trace_id](https://github.com/saasus-platform/saasus-sdk-javascript/pull/104) ブランチをクローンし npm run build を実行
  2. 本リポジトリの package.json を "saasus-sdk": "file:../saasus-sdk-javascript" に変更
  3. tsconfig.json に "ts-node": { "transpileOnly": true } を追加（型の不一致回避）
  4. npm install → npm run dev
  
  マージ条件
  
- saasus-platform/saasus-sdk-javascript#104
  がマージされ、npm に新バージョンとして publish された後、package.json の saasus-sdk
   バージョンをそれ以上に指定してからマージしてください。